### PR TITLE
feat: create go mod file if does not exist

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -2,6 +2,8 @@ name: github.com/rgst-io/stencil-golang
 postRunCommand:
   - name: mise install
     command: mise install
+  - name: mise run init
+    command: mise run init
   - name: mise run fmt
     command: mise run fmt
 arguments:
@@ -21,6 +23,13 @@ arguments:
         - Apache-2.0
         - GPL-3.0
         - Proprietary
+
+  modulePath:
+    description: |-
+      The go module path of the project.
+    schema:
+      type: string
+    required: true
 
   commands:
     description: |-

--- a/templates/.mise.toml.tpl
+++ b/templates/.mise.toml.tpl
@@ -22,6 +22,13 @@
 {{ $key }} = "{{ $val }}"
 {{- end }}
 
+[tasks.init]
+description = "Initialize go module"
+{{- if not (stencil.Exists "go.mod") }}
+{{- $modulePath := stencil.Arg "modulePath" }}
+  run = "go mod init {{ $modulePath }}"
+{{- end }}
+
 [tasks.build]
 description = "Build a binary for the current platform/architecture"
 run = "go build -trimpath -o ./bin/ -v ./cmd/..."


### PR DESCRIPTION
# What this PR does?
Adds an init command to `mise` file to initialise the `go.mod` file in case it does not exist.