### PR TITLE
feat: manage .gitattributes

### DIFF
--- a/templates/.gitattributes.tpl
+++ b/templates/.gitattributes.tpl
@@ -1,0 +1,7 @@
+go*.sum linguist-generated
+stencil.lock linguist-generated
+bun.lockb linguist-generated
+
+## <<Stencil::Block(custom)>>
+{{ file.Block "custom" }}
+## <</Stencil::Block>>


### PR DESCRIPTION
Manages `.gitattributes` for consumers.

```bash
$ git check-attr -a go.sum
go.sum: linguist-generated: set
$ git check-attr -a go.work.sum
go.work.sum: linguist-generated: set
$ git check-attr -a bun.lockb
bun.lockb: linguist-generated: set
```
