### PR TITLE
feat: support forgejo

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -3,10 +3,10 @@
 [tools]
 bun = "latest"
 git-cliff = "latest"
-golang = "1.23.5"
-golangci-lint = "1.63.4"
+golang = "1.24.0"
+golangci-lint = "1.64.5"
 goreleaser = "latest"
-"go:gotest.tools/gotestsum" = "v1.12.0"
+"go:gotest.tools/gotestsum" = "1.12.0"
 "go:golang.org/x/tools/cmd/goimports" = "latest"
 "go:mvdan.cc/sh/v3/cmd/shfmt" = "latest"
 "go:github.com/thenativeweb/get-next-version" = "latest"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rgst-io/stencil-golang
 
-go 1.23.4
+go 1.24
 
 require (
 	github.com/google/go-github/v68 v68.0.0

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -10,6 +10,26 @@ postRunCommand:
   - name: mise run fmt
     command: mise run fmt
 arguments:
+  vcs:
+    description: |-
+      VCS provider to use. "vcs_host" must be set when this is set to
+      anything other than github.
+    default: "github"
+    schema:
+      type: string
+      default: "github"
+      enum:
+        - github
+        - forgejo
+  vcs_host:
+    default: "github.com"
+    description: |-
+      URL of the VCS host to used. Currently only tested with Github
+      compatible-ish VCS providers like Forgejo. Must be provided when
+      vcs is set to anything other than Github.
+    schema:
+      type: string
+      default: "github.com"
   org:
     description: The Github organization to use for the project
     required: true

--- a/templates/.github/settings.yml.tpl
+++ b/templates/.github/settings.yml.tpl
@@ -1,3 +1,6 @@
+{{- if (ne (stencil.Arg "vcs") "github") }}
+{{- file.Skip "Not using Github" }}
+{{- end }}
 # Documentation can be found at:
 # https://github.com/repository-settings/app/blob/master/docs/configuration.md
 _extends: jaredallard/jaredallard:settings.yml

--- a/templates/.github/workflows/release.yaml.tpl
+++ b/templates/.github/workflows/release.yaml.tpl
@@ -39,12 +39,22 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
-      {{- /* renovate: datasource=github-tags packageName=jdx/mise-action */}}
+			{{- if (eq (stencil.Arg "vcs") "github") -}}
+			{{- /* renovate: datasource=github-tags packageName=jdx/mise-action */}}
       - uses: jdx/mise-action@v2
+			{{- else if (eq (stencil.Arg "vcs") "forgejo") }}
+      - uses: https://git.rgst.io/rgst-io/mise-action@v2
+			{{- end }}
         with:
           experimental: true
+				{{- if (eq (stencil.Arg "vcs") "forgejo") }}
+          ## <<Stencil::Block(forgejoGithubToken)>>
+          github_token: {{ (file.Block "forgejoGithubToken" | default "github_token: ''" | fromYaml).github_token | default "${{ github.token }}" }}
+          ## <</Stencil::Block>>
+				{{- else }}
         env:
           GH_TOKEN: {{ "${{" }} github.token {{ "}}" }}
+        {{- end }}
       - name: Get Go directories
         id: go
         run: |

--- a/templates/.github/workflows/tests.yaml.tpl
+++ b/templates/.github/workflows/tests.yaml.tpl
@@ -19,12 +19,22 @@ jobs:
     steps:
       {{- /* renovate: datasource=github-tags packageName=actions/checkout */}}
       - uses: actions/checkout@v4
-      {{- /* renovate: datasource=github-tags packageName=jdx/mise-action */}}
+			{{- if (eq (stencil.Arg "vcs") "github") -}}
+			{{- /* renovate: datasource=github-tags packageName=jdx/mise-action */}}
       - uses: jdx/mise-action@v2
+			{{- else if (eq (stencil.Arg "vcs") "forgejo") }}
+      - uses: https://git.rgst.io/rgst-io/mise-action@v2
+			{{- end }}
         with:
           experimental: true
+				{{- if (eq (stencil.Arg "vcs") "forgejo") }}
+          ## <<Stencil::Block(forgejoGithubToken)>>
+          github_token: {{ (file.Block "forgejoGithubToken" | default "github_token: ''" | fromYaml).github_token | default "${{ github.token }}" }}
+          ## <</Stencil::Block>>
+				{{- else }}
         env:
           GH_TOKEN: {{ "${{" }} github.token {{ "}}" }}
+        {{- end }}
       - name: Get Go directories
         id: go
         run: |
@@ -61,12 +71,22 @@ jobs:
     steps:
       {{- /* renovate: datasource=github-tags packageName=actions/checkout */}}
       - uses: actions/checkout@v4
-      {{- /* renovate: datasource=github-tags packageName=jdx/mise-action */}}
+			{{- if (eq (stencil.Arg "vcs") "github") -}}
+			{{- /* renovate: datasource=github-tags packageName=jdx/mise-action */}}
       - uses: jdx/mise-action@v2
+			{{- else if (eq (stencil.Arg "vcs") "forgejo") }}
+      - uses: https://git.rgst.io/rgst-io/mise-action@v2
+			{{- end }}
         with:
           experimental: true
+				{{- if (eq (stencil.Arg "vcs") "forgejo") }}
+          ## <<Stencil::Block(forgejoGithubToken)>>
+          github_token: {{ (file.Block "forgejoGithubToken" | default "github_token: ''" | fromYaml).github_token | default "${{ github.token }}" }}
+          ## <</Stencil::Block>>
+				{{- else }}
         env:
           GH_TOKEN: {{ "${{" }} github.token {{ "}}" }}
+        {{- end }}
       - name: Retrieve golangci-lint version
         run: |
           echo "version=$(mise current golangci-lint)" >> "$GITHUB_OUTPUT"

--- a/templates/.goreleaser.yaml.tpl
+++ b/templates/.goreleaser.yaml.tpl
@@ -51,8 +51,8 @@ dockers:
       - --platform=linux/amd64
       - --label=org.opencontainers.image.title={{ "{{ .ProjectName }}" }}
       - --label=org.opencontainers.image.description={{ "{{ .ProjectName }}" }}
-      - --label=org.opencontainers.image.url=https://github.com/{{ $org }}/{{ "{{ .ProjectName }}" }}
-      - --label=org.opencontainers.image.source=https://github.com/{{ $org }}/{{ "{{ .ProjectName }}" }}
+      - --label=org.opencontainers.image.url=https://{{ stencil.Arg "vcs_host" }}/{{ $org }}/{{ "{{ .ProjectName }}" }}
+      - --label=org.opencontainers.image.source=https://{{ stencil.Arg "vcs_host" }}/{{ $org }}/{{ "{{ .ProjectName }}" }}
       - --label=org.opencontainers.image.version={{ "{{ .Version }}" }}
       - --label=org.opencontainers.image.created={{ "{{ time \"2006-01-02T15:04:05Z07:00\" }}" }}
       - --label=org.opencontainers.image.revision={{ "{{ .FullCommit }}" }}
@@ -67,8 +67,8 @@ dockers:
       - --platform=linux/arm64
       - --label=org.opencontainers.image.title={{ "{{ .ProjectName }}" }}
       - --label=org.opencontainers.image.description={{ "{{ .ProjectName }}" }}
-      - --label=org.opencontainers.image.url=https://github.com/{{ $org }}/{{ "{{ .ProjectName }}" }}
-      - --label=org.opencontainers.image.source=https://github.com/{{ $org }}/{{ "{{ .ProjectName }}" }}
+      - --label=org.opencontainers.image.url=https://{{ stencil.Arg "vcs_host" }}/{{ $org }}/{{ "{{ .ProjectName }}" }}
+      - --label=org.opencontainers.image.source=https://{{ stencil.Arg "vcs_host" }}/{{ $org }}/{{ "{{ .ProjectName }}" }}
       - --label=org.opencontainers.image.version={{ "{{ .Version }}" }}
       - --label=org.opencontainers.image.created={{ "{{ time \"2006-01-02T15:04:05Z07:00\" }}" }}
       - --label=org.opencontainers.image.revision={{ "{{ .FullCommit }}" }}
@@ -90,7 +90,7 @@ changelog:
 release:
   prerelease: "auto"
   footer: |-
-    **Full Changelog**: https://github.com/{{ $org }}/{{ .Config.Name }}/compare/{{ "{{ .PreviousTag }}" }}...{{ "{{ .Tag }}" }}
+    **Full Changelog**: https://{{ stencil.Arg "vcs_host" }}/{{ $org }}/{{ .Config.Name }}/compare/{{ "{{ .PreviousTag }}" }}...{{ "{{ .Tag }}" }}
 
 ## <<Stencil::Block(extraReleaseOpts)>>
 {{ file.Block "extraReleaseOpts" }}

--- a/templates/.mise.toml.tpl
+++ b/templates/.mise.toml.tpl
@@ -4,19 +4,19 @@
 - bun: "latest"
 - git-cliff: "latest"
 # renovate: datasource=github-tags depName=golang packageName=golang/go
-- golang: "1.23.4"
+- golang: "1.24.0"
 # renovate: datasource=github-tags depName=golangci-lint packageName=golangci/golangci-lint
-- golangci-lint: "1.63.4"
+- golangci-lint: "1.64.5"
 - goreleaser: "latest"
 # renovate: datasource=go packageName=gotest.tools/gotestsum
-- go:gotest.tools/gotestsum: "v1.12.0"
+- go:gotest.tools/gotestsum: "1.12.0"
 - go:golang.org/x/tools/cmd/goimports: "latest"
 - go:mvdan.cc/sh/v3/cmd/shfmt: "latest"
 - go:github.com/thenativeweb/get-next-version: "latest"
 {{- end }}
 # Default versions of tools, to update these, set [tools.override]
 [tools]
-{{- range (fromYaml (stencil.ApplyTemplate "defaultVers")) }}
+{{- range (fromYaml (stencil.Include "defaultVers")) }}
 {{- $key := index (keys .) 0 }}
 {{- $val := index . $key }}
 {{- if contains ":" $key }}

--- a/templates/.vscode/common.code-snippets.tpl
+++ b/templates/.vscode/common.code-snippets.tpl
@@ -102,5 +102,5 @@ see <https://opensource.org/licenses/MIT>.
 	"Name" $license
 	"Body" ""
 )}}
-{{ set $licenseObj "Body" (stencil.ApplyTemplate (list "code-snippets" "copyright" $license | join ".") $licenseObj) }}
-{{ file.SetContents (stencil.ApplyTemplate "code-snippets.copyright" $licenseObj) }}
+{{ set $licenseObj "Body" (stencil.Include (list "code-snippets" "copyright" $license | join ".") $licenseObj) }}
+{{ file.SetContents (stencil.Include "code-snippets.copyright" $licenseObj) }}

--- a/templates/_helpers.library.tpl
+++ b/templates/_helpers.library.tpl
@@ -1,0 +1,9 @@
+{{- define "importPath" }}
+{{- stencil.Arg "vcs_host" }}
+{{- end }}
+
+
+# Validate arguments
+{{- if and (ne (stencil.Arg "vcs") "github") (empty (stencil.Arg "vcs_host")) }}
+{{ error "When vcs is not \"github\" vcs_host must be set." }}
+{{- end }}

--- a/templates/cmd/$name/name.go.tpl
+++ b/templates/cmd/$name/name.go.tpl
@@ -15,7 +15,7 @@ func main() {
   {{ $cmds := stencil.Arg "commands" | default (list .Config.Name) }}
   {{ range $cmds }}
   {{ file.Create (printf "cmd/%s/%s.go" . .) 0600 (now) }}
-  {{ file.SetContents (stencil.ApplyTemplate "cmd" .) }}
+  {{ file.SetContents (stencil.Include "cmd" .) }}
 
   # Static until we have a framework.
   {{ file.Static }}

--- a/templates/go.mod.tpl
+++ b/templates/go.mod.tpl
@@ -1,4 +1,4 @@
 {{- file.Static }}
-module github.com/{{ stencil.Arg "org" }}/{{ .Config.Name }}
+module {{ stencil.Include "importPath" }}/{{ stencil.Arg "org" }}/{{ .Config.Name }}
 
-go 1.22
+go 1.23

--- a/templates/package.json.tpl
+++ b/templates/package.json.tpl
@@ -2,7 +2,7 @@
 	"//": "Used for prettier",
 	"name": "@{{ stencil.Arg "org" }}/{{ .Config.Name}}",
 	"devDependencies": {
-		"prettier": "^3.3.2"
+		"prettier": "^3.5.1"
 	},
 	"private": true
 }


### PR DESCRIPTION
Adds support for other VCS providers through the new `vcs` and
`vcs_host` arguments, which are optional for Github (the default).

These are meant to be used for the new Forgejo support, which uses
Github Actions-like syntax, enabling minimal changes to get working. The
major change there is using a `mise` fork to enable passing a Github
token directly since Forgejo replaces that with a Forgejo token, which
breaks downloads.
