### PR TITLE
fix: switch to svu from get-next-version

### DIFF
--- a/.github/scripts/get-next-version.sh
+++ b/.github/scripts/get-next-version.sh
@@ -25,7 +25,7 @@ if [[ -n "$VERSION_OVERRIDE" ]]; then
 fi
 
 # Determine the next version as reported by the next-version command.
-next_version=$(get-next-version --prefix v 2>/dev/null | sed 's/-rc.*//' | tr -d '\n')
+next_version=$(svu next 2>/dev/null | sed 's/-rc.*//' | tr -d '\n')
 
 echo "Next release version: $next_version" >&2
 

--- a/.mise.toml
+++ b/.mise.toml
@@ -9,7 +9,7 @@ goreleaser = "latest"
 "go:gotest.tools/gotestsum" = "1.12.2"
 "go:golang.org/x/tools/cmd/goimports" = "latest"
 "go:mvdan.cc/sh/v3/cmd/shfmt" = "latest"
-"go:github.com/thenativeweb/get-next-version" = "latest"
+"go:github.com/caarlos0/svu" = "latest"
 
 [tasks.build]
 description = "Build a binary for the current platform/architecture"

--- a/templates/.github/scripts/get-next-version.sh.tpl
+++ b/templates/.github/scripts/get-next-version.sh.tpl
@@ -25,7 +25,7 @@ if [[ -n "$VERSION_OVERRIDE" ]]; then
 fi
 
 # Determine the next version as reported by the next-version command.
-next_version=$(get-next-version --prefix v 2>/dev/null | sed 's/-rc.*//' | tr -d '\n')
+next_version=$(svu next 2>/dev/null | sed 's/-rc.*//' | tr -d '\n')
 
 echo "Next release version: $next_version" >&2
 

--- a/templates/.mise.toml.tpl
+++ b/templates/.mise.toml.tpl
@@ -12,7 +12,7 @@
 - go:gotest.tools/gotestsum: "1.12.2"
 - go:golang.org/x/tools/cmd/goimports: "latest"
 - go:mvdan.cc/sh/v3/cmd/shfmt: "latest"
-- go:github.com/thenativeweb/get-next-version: "latest"
+- go:github.com/caarlos0/svu: "latest"
 {{- end }}
 # Default versions of tools, to update these, set [tools.override]
 [tools]


### PR DESCRIPTION
Switches from `get-next-version` to `svu`. Resolves #58.
