### PR TITLE
fix: use ubi backend for dprint

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,4 +1,7 @@
 
+[alias]
+dprint = "ubi:dprint/dprint"
+
 # Default versions of tools, to update these, set [tools.override]
 [tools]
 dprint = "latest"

--- a/templates/.mise.toml.tpl
+++ b/templates/.mise.toml.tpl
@@ -13,6 +13,9 @@
 - go:mvdan.cc/sh/v3/cmd/shfmt: "latest"
 - go:github.com/caarlos0/svu: "latest"
 {{- end }}
+[alias]
+dprint = "ubi:dprint/dprint"
+
 # Default versions of tools, to update these, set [tools.override]
 [tools]
 {{- range (fromYaml (stencil.Include "defaultVers")) }}


### PR DESCRIPTION
Jared reported that `dprint` doesn't install correctly on `linux/arm64`, which seems to be an upstream issue in `aqua`. In the meantime, it should be fine to just use the `ubi` backend for it.